### PR TITLE
1. Added dryrun option; 2. added check for video file names of time-stamp and not to rename those files

### DIFF
--- a/picture-sorter
+++ b/picture-sorter
@@ -27,6 +27,7 @@ if (!(src && (dst || reportOnly || metaFile))) {
   console.log("  -d - Destionation folder.");
   console.log("  -v - Verbose mode.");
   console.log("  -j - output the meta info (in json format) of all the pictures/videos under the source folder to a file");
+  console.log("  --dryrun - No actual operations will take place.");
   console.log("  --backup - copy files from Source to Destionation.");
   console.log("  --report - report picture count by camera models and extension names");
   console.log("");


### PR DESCRIPTION
1. Added dryrun option (--dryrun) in the command line to indicate no renaming and copying will take place.
2. Added check for video file names of time-stamp and not to rename those files
3. If source file name starts with a dot (.) this file will be ignored.